### PR TITLE
Warn when accessing packed fields with `munge!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ readme = "crates-io.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
+compiletest_rs = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,7 @@ macro_rules! munge {
             // SAFETY: None of this can ever be executed.
             unsafe {
                 ::core::hint::unreachable_unchecked();
-                let inner_ref = $value.deref();
-                let $($tokens)+ = ::core::ptr::read(inner_ref).assume_init();
+                let $($tokens)+ = &mut ::core::ptr::read($value.as_ptr());
             }
         }
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,19 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::PathBuf;
+
+fn run_mode(mode: &'static str) {
+    let mut config = compiletest::Config::default();
+
+    config.mode = mode.parse().expect("Invalid mode");
+    config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.target_rustcflags = Some("-L target/debug".to_string());
+    config.clean_rmeta();
+
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+    run_mode("ui");
+}

--- a/tests/ui/packed.rs
+++ b/tests/ui/packed.rs
@@ -1,0 +1,30 @@
+extern crate core;
+extern crate munge;
+
+use {
+    ::core::mem::MaybeUninit,
+    ::munge::munge,
+};
+
+fn main() {
+    #[repr(packed)]
+    struct Misalign<T> {
+        byte: u8,
+        inner: T,
+    }
+
+    let mut mu = MaybeUninit::<Misalign<Misalign<u32>>>::uninit();
+
+    munge!(let Misalign { byte: a, inner: Misalign { byte: b, inner } } = mu);
+    //^ WARNING: reference to packed field is unaligned
+    assert_eq!(a.write(1), &1);
+    assert_eq!(b.write(2), &2);
+    assert_eq!(inner.write(3), &3);
+
+    // SAFETY: `mu` is completely initialized.
+    let init = unsafe { mu.assume_init() };
+    assert_eq!(init.byte, 1);
+    assert_eq!(init.inner.byte, 2);
+    assert_eq!(init.inner.inner, 3);
+    //^ WARNING: reference to packed field is unaligned
+}

--- a/tests/ui/packed.stderr
+++ b/tests/ui/packed.stderr
@@ -1,0 +1,26 @@
+warning: reference to packed field is unaligned
+  --> $DIR/packed.rs:18:63
+   |
+18 |     munge!(let Misalign { byte: a, inner: Misalign { byte: b, inner } } = mu);
+   |                                                               ^^^^^
+   |
+   = note: `#[warn(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+warning: reference to packed field is unaligned
+  --> $DIR/packed.rs:28:5
+   |
+28 |     assert_eq!(init.inner.inner, 3);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+   = note: this warning originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
By taking a reference to the destructuring `MaybeUninit`, we force the
compiler to produce packed field warnings. This also adds
`compiletest_rs` to test that the warnings are preserved going forward.